### PR TITLE
empty dist dir before build

### DIFF
--- a/packages/react-json-input/package-lock.json
+++ b/packages/react-json-input/package-lock.json
@@ -1635,6 +1635,12 @@
         "chalk": "^4.0.0"
       }
     },
+    "@justinc/dir-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@justinc/dir-exists/-/dir-exists-2.1.0.tgz",
+      "integrity": "sha1-tf0JAx2LPectguRZg2p//qad7ZM=",
+      "dev": true
+    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz",
@@ -7689,6 +7695,15 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rmdir-cli": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/rmdir-cli/-/rmdir-cli-2.0.6.tgz",
+      "integrity": "sha1-RPVnG+kL47Fd23oPLl6jJftUcBo=",
+      "dev": true,
+      "requires": {
+        "@justinc/dir-exists": "^2.0.2"
       }
     },
     "rsvp": {

--- a/packages/react-json-input/package.json
+++ b/packages/react-json-input/package.json
@@ -25,10 +25,11 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:ci": "jest --ci",
+    "build:empty": "rmdir-cli dist",
     "build:js": "babel --extensions \".ts,.tsx\" lib --out-dir dist --ignore \"**/*.test.tsx\",\"lib/scss.d.ts\"",
     "build:js:watch": "babel --extensions \".ts,.tsx\" lib --out-dir dist --ignore \"**/*.test.tsx\",\"lib/scss.d.ts\" -w",
     "build:dts": "tsc",
-    "build": "npm run build:js && npm run build:dts",
+    "build": "npm run build:empty && npm run build:js && npm run build:dts",
     "prepack": "npm run build"
   },
   "dependencies": {
@@ -55,6 +56,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "jest": "^26.6.3",
     "node-sass": "^5.0.0",
+    "rmdir-cli": "^2.0.6",
     "ts-standard": "^10.0.0",
     "typescript": "^4.2.3"
   },


### PR DESCRIPTION
This prevents accidentally publishing files in `dist` which weren't supposed to be published.