### PR TITLE
Use build-tsconfig.json for build:dts

### DIFF
--- a/packages/react-json-input/package.json
+++ b/packages/react-json-input/package.json
@@ -28,7 +28,7 @@
     "build:empty": "rmdir-cli dist",
     "build:js": "babel --extensions \".ts,.tsx\" lib --out-dir dist --ignore \"**/*.test.tsx\",\"lib/scss.d.ts\"",
     "build:js:watch": "babel --extensions \".ts,.tsx\" lib --out-dir dist --ignore \"**/*.test.tsx\",\"lib/scss.d.ts\" -w",
-    "build:dts": "tsc",
+    "build:dts": "tsc --project build-tsconfig.json",
     "build": "npm run build:empty && npm run build:js && npm run build:dts",
     "prepack": "npm run build"
   },


### PR DESCRIPTION
Prevents publishing `*.test.d.ts` files.